### PR TITLE
Fix the parser to not search until the end of the string all the time.

### DIFF
--- a/lib/xml-parser.js
+++ b/lib/xml-parser.js
@@ -234,26 +234,29 @@ XMLP.prototype._parse = function() {
         return XMLP._NONE;
     }
 
+    // NB: 10 is "<!DOCTYPE ".length and the longest substring that we need to
+    // match.
+    var next = this.m_xml.substr(this.m_iP, 10);
     var fc = this.m_xml.charAt(this.m_iP);
     if (fc !== '<' && fc !== '&') {
-        return this._parseText   (this.m_iP);        
+        return this._parseText   (this.m_iP);
     }    
-    else if(this.m_iP == this.m_xml.indexOf("<?",        this.m_iP)) {
+    else if(next.indexOf("<?") === 0) {
         return this._parsePI     (this.m_iP + 2);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<!DOCTYPE", this.m_iP)) {
-        return this._parseDTD    (this.m_iP + 9);
+    else if(next.indexOf("<!DOCTYPE ") === 0) {
+        return this._parseDTD    (this.m_iP + 10);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<!--",      this.m_iP)) {
+    else if(next.indexOf("<!--") === 0) {
         return this._parseComment(this.m_iP + 4);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<![CDATA[", this.m_iP)) {
+    else if(next.indexOf("<![CDATA[") === 0) {
         return this._parseCDATA  (this.m_iP + 9);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<",         this.m_iP)) {
+    else if(next.indexOf("<") === 0) {
         return this._parseElement(this.m_iP + 1);
     }
-    else if(this.m_iP == this.m_xml.indexOf("&",         this.m_iP)) {
+    else if(next.indexOf("&") === 0) {
         return this._parseEntity (this.m_iP + 1);
     }
     else{


### PR DESCRIPTION
For very long strings, searching until the end of the string every time we
find a < is very expensive. In newer versions of JavaScript (ECMAScript 6) we
could use beginsWith, but that's not supported everywhere. This patch creates
one extra string per token, but significantly speeds up parsing very long
strings (~1mb).
